### PR TITLE
New Filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,13 @@ $value = \DominionEnterprises\Filter\String::explode('abc,def,ghi');
 assert($value === ['abc', 'def', 'ghi']);
 ```
 
+#### String::concat
+Aliased in the filterer as `concat`, this filter will prepend and/or append given strings to the filtered value. For example:
+```php
+$value = \DominionEnterprises\Filterer\String::concat('middle', false, 'start', 'end');
+assert($value === 'startmiddleend');
+```
+
 #### Url::filter
 Aliased in the filterer as `url`, this filter verifies that the argument is a URL string according to
 [RFC2396](http://www.faqs.org/rfcs/rfc2396).

--- a/README.md
+++ b/README.md
@@ -221,6 +221,14 @@ The following checks that `$value` is an email.
 \DominionEnterprises\Filter\Email::filter($value);
 ```
 
+#### DateTime::filter
+Aliased in the filterer as `date`, this will filter the value as a `\DateTime` object. The value can be any string that conforms to [PHP's valid date/time formats](http://php.net/manual/en/datetime.formats.php)
+
+The following checks that `$value` is a date/time.
+```php
+$dateTime = \DominionEnterprises\Filter\DateTime::filter('2014-02-04T11:55:00-0500');
+```
+
 ##Contact
 Developers may be contacted at:
 

--- a/README.md
+++ b/README.md
@@ -229,6 +229,13 @@ The following checks that `$value` is a date/time.
 $dateTime = \DominionEnterprises\Filter\DateTime::filter('2014-02-04T11:55:00-0500');
 ```
 
+#### DateTimeZone::filter
+Aliased in the filterer as `date`, this will filter the value as a `\DateTimeZone` object. The value can be any [supported timezone name](http://php.net/manual/en/timezones.php)
+
+The following checks that `$value` is a timezone
+```php
+$timezone = \DominionEnterprises\Filter\DateTimeZone::filter('America/New_York');
+```
 ##Contact
 Developers may be contacted at:
 

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
     "require": {
         "php": "~5.4"
     },
+    "suggest": {
+        "ext-timezonedb": "The latest version of the timezone database"
+    },
     "require-dev": {
         "phpunit/phpunit": "~4.1",
         "satooshi/php-coveralls": "~0.6.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,11 +4,65 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "29bbca3f23f3c69577770c7e78e11067",
+    "hash": "bb3011e4b20e6545c1fc3e232c35e8f1",
     "packages": [
 
     ],
     "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "8806c41c178ad4a2e87294b851d730779555d252"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8806c41c178ad4a2e87294b851d730779555d252",
+                "reference": "8806c41c178ad4a2e87294b851d730779555d252",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~5.3"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "2.0.*@ALPHA"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Instantiator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://github.com/doctrine/instantiator",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2014-10-04 22:48:25"
+        },
         {
             "name": "dominionenterprises/dws-coding-standard",
             "version": "v1.4.0",
@@ -152,119 +206,6 @@
                 "web service"
             ],
             "time": "2014-08-11 04:32:36"
-        },
-        {
-            "name": "ocramius/instantiator",
-            "version": "1.1.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Ocramius/Instantiator.git",
-                "reference": "e24a12178906ff2e7471b8aaf3a0eb789b59f881"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/Instantiator/zipball/e24a12178906ff2e7471b8aaf3a0eb789b59f881",
-                "reference": "e24a12178906ff2e7471b8aaf3a0eb789b59f881",
-                "shasum": ""
-            },
-            "require": {
-                "ocramius/lazy-map": "1.0.*",
-                "php": "~5.3"
-            },
-            "require-dev": {
-                "athletic/athletic": "~0.1.8",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "2.0.*@ALPHA"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Instantiator\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/Ocramius/Instantiator",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "time": "2014-08-25 14:48:16"
-        },
-        {
-            "name": "ocramius/lazy-map",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Ocramius/LazyMap.git",
-                "reference": "7fe3d347f5e618bcea7d39345ff83f3651d8b752"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/LazyMap/zipball/7fe3d347f5e618bcea7d39345ff83f3651d8b752",
-                "reference": "7fe3d347f5e618bcea7d39345ff83f3651d8b752",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "athletic/athletic": "~0.1.6",
-                "phpmd/phpmd": "1.5.*",
-                "phpunit/phpunit": ">=3.7",
-                "satooshi/php-coveralls": "~0.6",
-                "squizlabs/php_codesniffer": "1.4.*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "LazyMap\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/",
-                    "role": "Developer"
-                }
-            ],
-            "description": "A library that provides lazy instantiation logic for a map of objects",
-            "homepage": "https://github.com/Ocramius/LazyMap",
-            "keywords": [
-                "lazy",
-                "lazy instantiation",
-                "lazy loading",
-                "map",
-                "service location"
-            ],
-            "time": "2013-11-09 22:30:54"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -515,16 +456,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.2.4",
+            "version": "4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f0c2d374ad06ec1e56c721f4ed87c59ff35f440e"
+                "reference": "06005259429c156c02596add91f6a59c7dc3d4af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f0c2d374ad06ec1e56c721f4ed87c59ff35f440e",
-                "reference": "f0c2d374ad06ec1e56c721f4ed87c59ff35f440e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/06005259429c156c02596add91f6a59c7dc3d4af",
+                "reference": "06005259429c156c02596add91f6a59c7dc3d4af",
                 "shasum": ""
             },
             "require": {
@@ -538,7 +479,7 @@
                 "phpunit/php-file-iterator": "~1.3.1",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "~1.0.2",
-                "phpunit/phpunit-mock-objects": "~2.2",
+                "phpunit/phpunit-mock-objects": "~2.3",
                 "sebastian/comparator": "~1.0",
                 "sebastian/diff": "~1.1",
                 "sebastian/environment": "~1.0",
@@ -555,7 +496,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2.x-dev"
+                    "dev-master": "4.3.x-dev"
                 }
             },
             "autoload": {
@@ -585,29 +526,29 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2014-08-31 06:46:49"
+            "time": "2014-10-06 06:20:35"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.2.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "42e589e08bc86e3e9bdf20d385e948347788505b"
+                "reference": "c63d2367247365f688544f0d500af90a11a44c65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/42e589e08bc86e3e9bdf20d385e948347788505b",
-                "reference": "42e589e08bc86e3e9bdf20d385e948347788505b",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/c63d2367247365f688544f0d500af90a11a44c65",
+                "reference": "c63d2367247365f688544f0d500af90a11a44c65",
                 "shasum": ""
             },
             "require": {
-                "ocramius/instantiator": "~1.0",
+                "doctrine/instantiator": "~1.0,>=1.0.1",
                 "php": ">=5.3.3",
                 "phpunit/php-text-template": "~1.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.2.*@dev"
+                "phpunit/phpunit": "~4.3"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -615,7 +556,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2.x-dev"
+                    "dev-master": "2.3.x-dev"
                 }
             },
             "autoload": {
@@ -624,9 +565,6 @@
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
@@ -643,7 +581,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2014-08-02 13:50:58"
+            "time": "2014-10-03 05:12:11"
         },
         {
             "name": "psr/log",
@@ -753,16 +691,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "f7069ee51fa9fb6c038e16a9d0e3439f5449dcf2"
+                "reference": "e54a01c0da1b87db3c5a3c4c5277ddf331da4aef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/f7069ee51fa9fb6c038e16a9d0e3439f5449dcf2",
-                "reference": "f7069ee51fa9fb6c038e16a9d0e3439f5449dcf2",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e54a01c0da1b87db3c5a3c4c5277ddf331da4aef",
+                "reference": "e54a01c0da1b87db3c5a3c4c5277ddf331da4aef",
                 "shasum": ""
             },
             "require": {
@@ -790,11 +728,6 @@
             ],
             "authors": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                },
-                {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
                 },
@@ -805,6 +738,10 @@
                 {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
@@ -814,29 +751,32 @@
                 "compare",
                 "equality"
             ],
-            "time": "2014-05-02 07:05:58"
+            "time": "2014-05-11 23:00:21"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "1e091702a5a38e6b4c1ba9ca816e3dd343df2e2d"
+                "reference": "5843509fed39dee4b356a306401e9dd1a931fec7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/1e091702a5a38e6b4c1ba9ca816e3dd343df2e2d",
-                "reference": "1e091702a5a38e6b4c1ba9ca816e3dd343df2e2d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/5843509fed39dee4b356a306401e9dd1a931fec7",
+                "reference": "5843509fed39dee4b356a306401e9dd1a931fec7",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "1.2-dev"
                 }
             },
             "autoload": {
@@ -850,13 +790,12 @@
             ],
             "authors": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                },
-                {
                     "name": "Kore Nordmann",
                     "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Diff implementation",
@@ -864,32 +803,32 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2013-08-03 16:46:33"
+            "time": "2014-08-15 10:29:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "79517609ec01139cd7e9fded0dd7ce08c952ef6a"
+                "reference": "6288ebbf6fa3ed2b2ff2d69c356fbaaf4f0971a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/79517609ec01139cd7e9fded0dd7ce08c952ef6a",
-                "reference": "79517609ec01139cd7e9fded0dd7ce08c952ef6a",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6288ebbf6fa3ed2b2ff2d69c356fbaaf4f0971a7",
+                "reference": "6288ebbf6fa3ed2b2ff2d69c356fbaaf4f0971a7",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.0.*@dev"
+                "phpunit/phpunit": "~4.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -904,8 +843,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
@@ -915,27 +853,27 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2014-02-18 16:17:19"
+            "time": "2014-10-07 09:23:16"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "1f9a98e6f5dfe0524cb8c6166f7c82f3e9ae1529"
+                "reference": "c7d59948d6e82818e1bdff7cadb6c34710eb7dc0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/1f9a98e6f5dfe0524cb8c6166f7c82f3e9ae1529",
-                "reference": "1f9a98e6f5dfe0524cb8c6166f7c82f3e9ae1529",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/c7d59948d6e82818e1bdff7cadb6c34710eb7dc0",
+                "reference": "c7d59948d6e82818e1bdff7cadb6c34710eb7dc0",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.0.*@dev"
+                "phpunit/phpunit": "~4.0"
             },
             "type": "library",
             "extra": {
@@ -954,11 +892,6 @@
             ],
             "authors": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                },
-                {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
                 },
@@ -967,13 +900,16 @@
                     "email": "github@wallbash.com"
                 },
                 {
-                    "name": "Adam Harvey",
-                    "email": "aharvey@php.net",
-                    "role": "Lead"
-                },
-                {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
@@ -982,7 +918,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2014-02-16 08:26:31"
+            "time": "2014-09-10 00:51:36"
         },
         {
             "name": "sebastian/version",
@@ -1021,16 +957,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "1.5.4",
+            "version": "1.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "4097e2c106e4a32bc234ae880e5585a19137e435"
+                "reference": "5d973e59cf58a0c847f298de84374c96b42b17b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4097e2c106e4a32bc234ae880e5585a19137e435",
-                "reference": "4097e2c106e4a32bc234ae880e5585a19137e435",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5d973e59cf58a0c847f298de84374c96b42b17b3",
+                "reference": "5d973e59cf58a0c847f298de84374c96b42b17b3",
                 "shasum": ""
             },
             "require": {
@@ -1092,21 +1028,21 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2014-08-05 23:54:05"
+            "time": "2014-09-25 03:33:46"
         },
         {
             "name": "symfony/config",
-            "version": "v2.5.4",
+            "version": "v2.5.5",
             "target-dir": "Symfony/Component/Config",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Config.git",
-                "reference": "080eabdc256c1d7a3a7cf6296271edb68eb1ab2b"
+                "reference": "0316364bfebc8b080077c731a99f189341476bd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Config/zipball/080eabdc256c1d7a3a7cf6296271edb68eb1ab2b",
-                "reference": "080eabdc256c1d7a3a7cf6296271edb68eb1ab2b",
+                "url": "https://api.github.com/repos/symfony/Config/zipball/0316364bfebc8b080077c731a99f189341476bd7",
+                "reference": "0316364bfebc8b080077c731a99f189341476bd7",
                 "shasum": ""
             },
             "require": {
@@ -1140,21 +1076,21 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "http://symfony.com",
-            "time": "2014-08-31 03:22:04"
+            "time": "2014-09-23 05:25:11"
         },
         {
             "name": "symfony/console",
-            "version": "v2.5.4",
+            "version": "v2.5.5",
             "target-dir": "Symfony/Component/Console",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Console.git",
-                "reference": "748beed2a1e73179c3f5154d33fe6ae100c1aeb1"
+                "reference": "ca053eaa031c93afb68a71e4eb1f4168dfd4a661"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/748beed2a1e73179c3f5154d33fe6ae100c1aeb1",
-                "reference": "748beed2a1e73179c3f5154d33fe6ae100c1aeb1",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/ca053eaa031c93afb68a71e4eb1f4168dfd4a661",
+                "reference": "ca053eaa031c93afb68a71e4eb1f4168dfd4a661",
                 "shasum": ""
             },
             "require": {
@@ -1195,21 +1131,21 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "http://symfony.com",
-            "time": "2014-08-14 16:10:54"
+            "time": "2014-09-25 09:53:56"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.5.4",
+            "version": "v2.5.5",
             "target-dir": "Symfony/Component/EventDispatcher",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/EventDispatcher.git",
-                "reference": "8faf5cc7e80fde74a650a36e60d32ce3c3e0457b"
+                "reference": "f6281337bf5f985f585d1db6a83adb05ce531f46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/8faf5cc7e80fde74a650a36e60d32ce3c3e0457b",
-                "reference": "8faf5cc7e80fde74a650a36e60d32ce3c3e0457b",
+                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/f6281337bf5f985f585d1db6a83adb05ce531f46",
+                "reference": "f6281337bf5f985f585d1db6a83adb05ce531f46",
                 "shasum": ""
             },
             "require": {
@@ -1218,7 +1154,7 @@
             "require-dev": {
                 "psr/log": "~1.0",
                 "symfony/config": "~2.0",
-                "symfony/dependency-injection": "~2.0",
+                "symfony/dependency-injection": "~2.0,<2.6.0",
                 "symfony/stopwatch": "~2.2"
             },
             "suggest": {
@@ -1252,21 +1188,21 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "http://symfony.com",
-            "time": "2014-07-28 13:20:46"
+            "time": "2014-09-28 15:56:11"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.5.4",
+            "version": "v2.5.5",
             "target-dir": "Symfony/Component/Filesystem",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Filesystem.git",
-                "reference": "a765efd199e02ff4001c115c318e219030be9364"
+                "reference": "4e62fab0060a826561c78b665925b37c870c45f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/a765efd199e02ff4001c115c318e219030be9364",
-                "reference": "a765efd199e02ff4001c115c318e219030be9364",
+                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/4e62fab0060a826561c78b665925b37c870c45f5",
+                "reference": "4e62fab0060a826561c78b665925b37c870c45f5",
                 "shasum": ""
             },
             "require": {
@@ -1299,21 +1235,21 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "http://symfony.com",
-            "time": "2014-09-03 09:00:14"
+            "time": "2014-09-22 09:14:18"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v2.5.4",
+            "version": "v2.5.5",
             "target-dir": "Symfony/Component/Stopwatch",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Stopwatch.git",
-                "reference": "22ab4f76cdeefd38b00022a6be5709190a2fd046"
+                "reference": "9f8a33a24f2378c0ec5f372a8d50b2d43069c050"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Stopwatch/zipball/22ab4f76cdeefd38b00022a6be5709190a2fd046",
-                "reference": "22ab4f76cdeefd38b00022a6be5709190a2fd046",
+                "url": "https://api.github.com/repos/symfony/Stopwatch/zipball/9f8a33a24f2378c0ec5f372a8d50b2d43069c050",
+                "reference": "9f8a33a24f2378c0ec5f372a8d50b2d43069c050",
                 "shasum": ""
             },
             "require": {
@@ -1346,21 +1282,21 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "http://symfony.com",
-            "time": "2014-08-14 16:10:54"
+            "time": "2014-09-22 09:14:18"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.5.4",
+            "version": "v2.5.5",
             "target-dir": "Symfony/Component/Yaml",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Yaml.git",
-                "reference": "01a7695bcfb013d0a15c6757e15aae120342986f"
+                "reference": "b1dbc53593b98c2d694ebf383660ac9134d30b96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/01a7695bcfb013d0a15c6757e15aae120342986f",
-                "reference": "01a7695bcfb013d0a15c6757e15aae120342986f",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/b1dbc53593b98c2d694ebf383660ac9134d30b96",
+                "reference": "b1dbc53593b98c2d694ebf383660ac9134d30b96",
                 "shasum": ""
             },
             "require": {
@@ -1393,7 +1329,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "http://symfony.com",
-            "time": "2014-08-31 03:22:04"
+            "time": "2014-09-22 09:14:18"
         }
     ],
     "aliases": [

--- a/src/Filter/DateTime.php
+++ b/src/Filter/DateTime.php
@@ -1,0 +1,42 @@
+<?php
+namespace DominionEnterprises\Filter;
+
+/**
+ * A collection of filters for filtering strings into \DateTime objects.
+ */
+class DateTime
+{
+    /**
+     * Filters the given value into a \DateTime object.
+     *
+     * @param mixed         $value     The value to be filtered.
+     * @param boolean       $allowNull True to allow nulls through, and false (default) if nulls should not be allowed.
+     * @param \DateTimeZone $timezone  A \DateTimeZone object representing the timezone of $value.
+     *                                 If $timezone is omitted, the current timezone will be used.
+     *
+     * @return \DateTime
+     *
+     * @throws \InvalidArgumentException Thrown if $allowNull was not a boolean value.
+     * @throws \Exception if the value did not pass validation.
+     */
+    public static function filter($value, $allowNull = false, \DateTimeZone $timezone = null)
+    {
+        if ($allowNull !== false && $allowNull !== true) {
+            throw new \InvalidArgumentException('$allowNull was not a boolean value');
+        }
+
+        if ($value === null && $allowNull) {
+            return null;
+        }
+
+        if ($value instanceof \DateTime) {
+            return $value;
+        }
+
+        if (!is_string($value) || trim($value) == '') {
+            throw new \Exception('$value is not a non-empty string');
+        }
+
+        return new \DateTime($value, $timezone);
+    }
+}

--- a/src/Filter/DateTimeZone.php
+++ b/src/Filter/DateTimeZone.php
@@ -1,0 +1,40 @@
+<?php
+namespace DominionEnterprises\Filter;
+
+/**
+ * A collection of filters for filtering strings into \DateTimeZone objects.
+ */
+class DateTimeZone
+{
+    /**
+     * Filters the given value into a \DateTimeZone object.
+     *
+     * @param mixed   $value     The value to be filtered.
+     * @param boolean $allowNull True to allow nulls through, and false (default) if nulls should not be allowed.
+     *
+     * @return \DateTimeZone
+     *
+     * @throws \InvalidArgumentException Thrown if $allowNull was not a boolean value.
+     * @throws \Exception if the value did not pass validation.
+     */
+    public static function filter($value, $allowNull = false)
+    {
+        if ($allowNull !== false && $allowNull !== true) {
+            throw new \InvalidArgumentException('$allowNull was not a boolean value');
+        }
+
+        if ($value === null && $allowNull) {
+            return null;
+        }
+
+        if ($value instanceof \DateTimeZone) {
+            return $value;
+        }
+
+        if (!is_string($value) || trim($value) == '') {
+            throw new \Exception('$value not a non-empty string');
+        }
+
+        return new \DateTimeZone($value);
+    }
+}

--- a/src/Filter/String.php
+++ b/src/Filter/String.php
@@ -82,4 +82,39 @@ final class String
 
         return explode($delimiter, $value);
     }
+
+    /**
+     * Method to concat the given prefix and suffix to the given string value.
+     *
+     * @param mixed   $value     The starting value. This value must be castable as a string.
+     * @param boolean $allowNull True to allow nulls through, and false (default) if nulls should not be allowed.
+     * @param string  $prefix    The value to prepend to $value.
+     * @param string  $suffix    The value to append to $value.
+     *
+     * @return string
+     *
+     * @throws \InvalidArgumentException Thrown if $prefix is not a string.
+     * @throws \InvalidArgumentException Thrown if $suffix is not a string.
+     * @throws \Exception Thrown if $value fails validation.
+     */
+    public static function concat($value, $allowNull = false, $prefix = '', $suffix = '')
+    {
+        if ($allowNull !== false && $allowNull !== true) {
+            throw new \InvalidArgumentException('$allowNull was not a boolean value');
+        }
+
+        if (!is_string($prefix)) {
+            throw new \InvalidArgumentException('$prefix was not a string');
+        }
+
+        if (!is_string($suffix)) {
+            throw new \InvalidArgumentException('$suffix was not a string');
+        }
+
+        if (is_scalar($value) || (is_object($value) && method_exists($value, '__toString')) || ($allowNull && $value === null)) {
+            return "{$prefix}{$value}{$suffix}";
+        }
+
+        throw new \Exception('$value was not filterable as a string');
+    }
 }

--- a/src/Filterer.php
+++ b/src/Filterer.php
@@ -26,6 +26,7 @@ final class Filterer
         'explode' => '\DominionEnterprises\Filter\String::explode',
         'flatten' => '\DominionEnterprises\Filter\Arrays::flatten',
         'date' => '\DominionEnterprises\Filter\DateTime::filter',
+        'timezone' => '\DominionEnterprises\Filter\DateTimeZone::filter',
     ];
 
     /**

--- a/src/Filterer.php
+++ b/src/Filterer.php
@@ -25,6 +25,7 @@ final class Filterer
         'email' => '\DominionEnterprises\Filter\Email::filter',
         'explode' => '\DominionEnterprises\Filter\String::explode',
         'flatten' => '\DominionEnterprises\Filter\Arrays::flatten',
+        'date' => '\DominionEnterprises\Filter\DateTime::filter',
     ];
 
     /**

--- a/src/Filterer.php
+++ b/src/Filterer.php
@@ -27,6 +27,7 @@ final class Filterer
         'flatten' => '\DominionEnterprises\Filter\Arrays::flatten',
         'date' => '\DominionEnterprises\Filter\DateTime::filter',
         'timezone' => '\DominionEnterprises\Filter\DateTimeZone::filter',
+        'concat' => '\DominionEnterprises\Filter\String::concat',
     ];
 
     /**

--- a/tests/Filter/DateTimeTest.php
+++ b/tests/Filter/DateTimeTest.php
@@ -1,0 +1,140 @@
+<?php
+namespace DominionEnterprises\Filter;
+
+use DominionEnterprises\Filter\DateTime as D;
+/**
+ * Unit tests for the \DominionEnterprises\Filter\DateTime class.
+ *
+ * @coversDefaultClass \DominionEnterprises\Filter\DateTime
+ */
+final class DateTimeTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Verify basic usage of filter().
+     *
+     * @test
+     * @covers ::filter
+     *
+     * @return void
+     */
+    public function filter()
+    {
+        $string = '2014-02-04T11:55:00-0500';
+        $dateTime = D::filter($string);
+
+        $this->assertSame(strtotime($string), $dateTime->getTimestamp());
+    }
+
+    /**
+     * Verify behavior of filter() when $value is an integer.
+     *
+     * @test
+     * @covers ::filter
+     *
+     * @return void
+     */
+    public function filter_timestamp()
+    {
+        $now = time();
+        $dateTime = D::filter("@{$now}");
+
+        $this->assertSame($now, $dateTime->getTimestamp());
+    }
+
+    /**
+     * Verify behavior of filter() when $value is a string with only whitespace.
+     *
+     * @param mixed $value The value to be filtered.
+     *
+     * @test
+     * @covers ::filter
+     * @expectedException \Exception
+     * @expectedExceptionMessage $value is not a non-empty string
+     *
+     * @return void
+     */
+    public function filter_emptyValue()
+    {
+        D::filter("\t \n");
+    }
+
+    /**
+     * Verify behavior of filter() when $value is not a string or integer.
+     *
+     * @param mixed $value The value to be filtered.
+     *
+     * @test
+     * @covers ::filter
+     * @expectedException \Exception
+     * @expectedExceptionMessage $value is not a non-empty string
+     *
+     * @return void
+     */
+    public function filter_invalidValue()
+    {
+        D::filter(true);
+    }
+
+    /**
+     * Verify behavior of filter() when $allowNull is not a boolean.
+     *
+     * @test
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage $allowNull was not a boolean value
+     * @covers ::filter
+     */
+    public function filter_allowNullNotBoolean()
+    {
+        D::filter('n/a', 5);
+    }
+
+    /**
+     * Verify behavior of filter() when null is given for $value and $allowNull is true.
+     *
+     * @test
+     * @covers ::filter
+     */
+    public function filter_nullAllowed()
+    {
+        $this->assertNull(D::filter(null, true));
+    }
+
+    /**
+     * Verify behavior of filter() when null is given for $value and $allowNull is true.
+     *
+     * @test
+     * @covers ::filter
+     * @expectedException \Exception
+     * @expectedExceptionMessage $value is not a non-empty string
+     */
+    public function filter_nullNotAllowed()
+    {
+        D::filter(null, false);
+    }
+
+    /**
+     * Verify behavior of filter() when $value is a \DateTime object.
+     *
+     * @test
+     * @covers ::filter
+     */
+    public function filter_dateTimePass()
+    {
+        $dateTime = new \DateTime('now');
+        $this->assertSame($dateTime, D::filter($dateTime));
+    }
+
+    /**
+     * Verify behavior of filter() when $timezone is given.
+     *
+     * @test
+     * @covers ::filter
+     */
+    public function filter_withTimeZone()
+    {
+        $timezone = new \DateTimeZone('Pacific/Honolulu');
+        $dateTime = D::filter('now', false, $timezone);
+        $this->assertSame($timezone->getName(), $dateTime->getTimeZone()->getName());
+        $this->assertSame(-36000, $dateTime->getOffset());
+    }
+}

--- a/tests/Filter/DateTimeZoneTest.php
+++ b/tests/Filter/DateTimeZoneTest.php
@@ -1,0 +1,106 @@
+<?php
+namespace DominionEnterprises\Filter;
+use DominionEnterprises\Filter\DateTimeZone as TZ;
+
+/**
+ * Unit tests for the \DominionEnterprises\Filter\DateTimeZone class.
+ *
+ * @coversDefaultClass \DominionEnterprises\Filter\DateTimeZone
+ */
+final class DateTimeZoneTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Verify basic usage of filter().
+     *
+     * @test
+     * @covers ::filter
+     *
+     * @return void
+     */
+    public function filter()
+    {
+        $value = 'Pacific/Honolulu';
+        $timezone = TZ::filter($value);
+        $this->assertSame($value, $timezone->getName());
+        $this->assertSame(-36000, $timezone->getOffset(new \DateTime('now', $timezone)));
+    }
+
+    /**
+     * Verify behavior of filter() when $allowNull is not true or false.
+     *
+     * @test
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage $allowNull was not a boolean value
+     * @covers ::filter
+     */
+    public function filter_allowNullNotBoolean()
+    {
+        TZ::filter('America/New_York', 5);
+    }
+
+    /**
+     * Verify behavior of filter() when $allowNull is true and $value is null.
+     *
+     * @test
+     * @covers ::filter
+     */
+    public function filter_nullAllowed()
+    {
+        $this->assertNull(TZ::filter(null, true));
+    }
+
+    /**
+     * Verify behavior of filter() when $allowNull is false and $value is null.
+     *
+     * @test
+     * @covers ::filter
+     * @expectedException \Exception
+     * @expectedExceptionMessage $value not a non-empty string
+     */
+    public function filter_nullNotAllowed()
+    {
+        $this->assertNull(TZ::filter(null, false));
+    }
+
+    /**
+     * Verify behavior of filter() when $value is a \DateTimeZone object.
+     *
+     * @test
+     * @covers ::filter
+     */
+    public function filter_timeZonePass()
+    {
+        $timezone = new \DateTimeZone('America/New_York');
+        $this->assertSame($timezone, TZ::filter($timezone));
+    }
+
+    /**
+     * Verify behavior of filter() when $value is not a valid timezone.
+     *
+     * @test
+     * @covers ::filter
+     * @expectedException \Exception
+     * @expectedExceptionMessage Unknown or bad timezone (INVALID)
+     */
+    public function filter_invalidName()
+    {
+        $timezone = TZ::filter('INVALID');
+    }
+
+    /**
+     * Verify behavior of filter() $value is a string with only whitespace.
+     *
+     * @param mixed $value The value to be filtered.
+     *
+     * @test
+     * @covers ::filter
+     * @expectedException \Exception
+     * @expectedExceptionMessage $value not a non-empty string
+     *
+     * @return void
+     */
+    public function filter_emptyValue()
+    {
+        TZ::filter("\n\t");
+    }
+}

--- a/tests/Filter/StringTest.php
+++ b/tests/Filter/StringTest.php
@@ -192,4 +192,110 @@ final class StringUtilTest extends \PHPUnit_Framework_TestCase
     {
         S::explode('test', '');
     }
+
+    /**
+     * Verify basic behvaior of concat().
+     *
+     * @test
+     * @covers ::concat
+     *
+     * @return void
+     */
+    public function concat()
+    {
+        $this->assertSame('prefixstringsuffix', S::concat('string', false, 'prefix', 'suffix'));
+    }
+
+    /**
+     * Verify behavior of concat() when $allowNull is not a boolean.
+     *
+     * @test
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage $allowNull was not a boolean value
+     * @covers ::concat
+     */
+    public function concat_allowNullNotBoolean()
+    {
+        S::concat('n/a', 5, 'prefix', 'suffix');
+    }
+
+    /**
+     * Verify behavior of concat() when null is given for $value and $allowNull is true.
+     *
+     * @test
+     * @covers ::concat
+     */
+    public function concat_nullAllowed()
+    {
+        $this->assertSame('prefixsuffix', S::concat(null, true, 'prefix', 'suffix'));
+    }
+
+    /**
+     * Verify behavior of concat() when null is given for $value and $allowNull is true.
+     *
+     * @test
+     * @covers ::concat
+     * @expectedException \Exception
+     * @expectedExceptionMessage $value was not filterable as a string
+     */
+    public function concat_nullNotAllowed()
+    {
+        S::concat(null, false, 'prefix', 'suffix');
+    }
+
+    /**
+     * Verify behavior of concat() when $prefix is not a string.
+     *
+     * @test
+     * @covers ::concat
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage $prefix was not a string
+     *
+     * @return void
+     */
+    public function concat_nonStringPrefix()
+    {
+        S::concat('string', false, true, 'suffix');
+    }
+
+    /**
+     * Verify behavior of concat() when $suffix is not a string.
+     *
+     * @test
+     * @covers ::concat
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage $suffix was not a string
+     *
+     * @return void
+     */
+    public function concat_nonStringSuffix()
+    {
+        S::concat('string', false, 'prefix', 0.00);
+    }
+
+    /**
+     * Verify behavior of concat() when $value is a non-string scalar.
+     *
+     * @test
+     * @covers ::concat
+     *
+     * @return void
+     */
+    public function concat_scalarValue()
+    {
+        $this->assertSame('prefix123suffix', S::concat(123, false, 'prefix', 'suffix'));
+    }
+
+    /**
+     * Verify behavior of concat() when $value is an object that implements __toString().
+     *
+     * @test
+     * @covers ::concat
+     *
+     * @return void
+     */
+    public function concat_objectValue()
+    {
+        $this->assertSame('prefix' . __FILE__ . 'suffix', S::concat(new \SplFileInfo(__FILE__), false, 'prefix', 'suffix'));
+    }
 }


### PR DESCRIPTION
Add `Filter\DateTime`   filters incoming value into a `\DateTime` object
Add `Filter\DateTimeZone` filters incoming value into a `\DateTimeZone` object
Add `Filter\String::concat` allows prepending and/or appending values to incoming string values.

Primary Use Case:   timestamp validation
```php
$filters = [
    'timestamp' => [
        ['uint'], //ensure value is an unsigned integer
        ['concat', false, '@'], //prepend an '@' character to the integer
        ['date'], //filter the `@timestamp` as a \DateTime
    ],
];
```

