### PR TITLE
Add DateTime::format()

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,14 @@ The following checks that `$value` is a date/time.
 $dateTime = \DominionEnterprises\Filter\DateTime::filter('2014-02-04T11:55:00-0500');
 ```
 
+#### DateTime::format
+Aliased in the filterer as `date-format`, this will filter a given `\DateTime' value to a string based on the given format.
+
+The following returns formatted string for a given `\DateTime` `$value`
+```php
+$formatted = \DominionEnterprises\Filter\DateTime::format($value, 'Y-m-d H:i:s');
+```
+
 #### DateTimeZone::filter
 Aliased in the filterer as `date`, this will filter the value as a `\DateTimeZone` object. The value can be any [supported timezone name](http://php.net/manual/en/timezones.php)
 

--- a/src/Filter/DateTime.php
+++ b/src/Filter/DateTime.php
@@ -43,4 +43,23 @@ class DateTime
 
         return new \DateTime($value, $timezone);
     }
+
+    /**
+     * Filters the give \DateTime object to a formatted string.
+     *
+     * @param \DateTimeInterface $dateTime The date to be formatted.
+     * @param string             $format   The format of the outputted date string.
+     *
+     * @return string
+     *
+     * @throws \InvalidArgumentException Thrown if $format is not a string
+     */
+    public static function format(\DateTimeInterface $dateTime, $format = 'c')
+    {
+        if (!is_string($format) || trim($format) === '') {
+            throw new \InvalidArgumentException('$format is not a non-empty string');
+        }
+
+        return $dateTime->format($format);
+    }
 }

--- a/src/Filterer.php
+++ b/src/Filterer.php
@@ -27,6 +27,7 @@ final class Filterer
         'explode' => '\DominionEnterprises\Filter\Strings::explode',
         'flatten' => '\DominionEnterprises\Filter\Arrays::flatten',
         'date' => '\DominionEnterprises\Filter\DateTime::filter',
+        'date-format' => '\DominionEnterprises\Filter\DateTime::format',
         'timezone' => '\DominionEnterprises\Filter\DateTimeZone::filter',
     ];
 

--- a/tests/Filter/DateTimeTest.php
+++ b/tests/Filter/DateTimeTest.php
@@ -149,4 +149,29 @@ final class DateTimeTest extends \PHPUnit_Framework_TestCase
         $dateTime = DateTime::filter($now);
         $this->assertSame($now, $dateTime->getTimestamp());
     }
+
+    /**
+     * Verify behavior of format() when $format is not a string
+     *
+     * @test
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage $format is not a non-empty string
+     * @covers ::format
+     */
+    public function formatNonStringFormat()
+    {
+        DateTime::format(new \DateTime(), true);
+    }
+
+    /**
+     * Verify basic behavior of format().
+     *
+     * @test
+     * @covers ::format
+     */
+    public function format()
+    {
+        $now = new \DateTime();
+        $this->assertSame($now->format('Y-m-d H:i:s'), DateTime::format($now, 'Y-m-d H:i:s'));
+    }
 }


### PR DESCRIPTION
My use case for this change is when you have code that filters and passes data on to another operation. And that operation only takes valid date strings.

Without `date-format` filter
```php
public function passthru(array $criteria) 
{
    $filters = [
        'minCreate' => [['date']],
        'aField' => [['string']],
        'anotherField' => [['uint']],
    ];

    list($success, $filtered, $error) = Filterer::filter($filters, $criteria);
    Util::ensure(true, $success, $error);

    $minCreate = Util\Arrays::get($filtered, 'minCreate');
    if ($minCreate !== null) {
        $filtered['minCreate'] = $minCreate->format('Y-m-d');
    }

    ThirdParty::functionOptionallyTakesMinCreateButOnlyAsString($filtered);
}
```
With `date-format` filter
```php
public function passthru(array $criteria) 
{
    $filters = [
        'minCreate' => [['date'], ['date-format', 'Y-m-d']],
        'aField' => [['string']],
        'anotherField' => [['uint']],
    ];

    list($success, $filtered, $error) = Filterer::filter($filters, $criteria);
    Util::ensure(true, $success, $error);

    ThirdParty::functionOptionallyTakesMinCreateButOnlyAsString($filtered);
}
```
Alternative without `date-format` filter
```php
public function passthru(array $criteria) 
{
    $format = function ($date) {
        return $date->format('Y-m-d');
    };

    $filters = [
        'minCreate' => [['date'], [$format]],
        'aField' => [['string']],
        'anotherField' => [['uint']],
    ];

    list($success, $filtered, $error) = Filterer::filter($filters, $criteria);
    Util::ensure(true, $success, $error);

    ThirdParty::functionOptionallyTakesMinCreateButOnlyAsString($filtered);
}
```
This approach is cleaner than the first, however it's not reusable.