### PR TITLE
Disambiguate class names in tests.

### DIFF
--- a/tests/Filter/ArraysTest.php
+++ b/tests/Filter/ArraysTest.php
@@ -1,8 +1,6 @@
 <?php
 namespace DominionEnterprises\Filter;
 
-use DominionEnterprises\Filter\Arrays as A;
-
 /**
  * @coversDefaultClass \DominionEnterprises\Filter\Arrays
  */
@@ -14,7 +12,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
      */
     public function filterBasicPass()
     {
-        $this->assertSame(['boo'], A::filter(['boo']));
+        $this->assertSame(['boo'], Arrays::filter(['boo']));
     }
 
     /**
@@ -25,7 +23,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
      */
     public function filterFailNotArray()
     {
-        A::filter(1);
+        Arrays::filter(1);
     }
 
     /**
@@ -36,7 +34,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
      */
     public function filterFailEmpty()
     {
-        A::filter([]);
+        Arrays::filter([]);
     }
 
     /**
@@ -47,7 +45,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
      */
     public function filterCountLessThanMin()
     {
-        A::filter([0], 2);
+        Arrays::filter([0], 2);
     }
 
     /**
@@ -58,7 +56,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
      */
     public function filterCountGreaterThanMax()
     {
-        A::filter([0, 1], 1, 1);
+        Arrays::filter([0, 1], 1, 1);
     }
 
     /**
@@ -69,7 +67,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
      */
     public function filterMinCountNotInt()
     {
-        A::filter([], true);
+        Arrays::filter([], true);
     }
 
     /**
@@ -80,7 +78,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
      */
     public function filterMaxCountNotInt()
     {
-        A::filter([], 0, true);
+        Arrays::filter([], 0, true);
     }
 
     /**
@@ -89,7 +87,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
      */
     public function inPassStrict()
     {
-        $this->assertSame('boo', A::in('boo', ['boo']));
+        $this->assertSame('boo', Arrays::in('boo', ['boo']));
     }
 
     /**
@@ -99,7 +97,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
     public function inFailStrict()
     {
         try {
-            A::in('0', [0]);
+            Arrays::in('0', [0]);
             $this->fail();
         } catch (\Exception $e) {
             $this->assertSame("Value '0' is not in array array (\n  0 => 0,\n)", $e->getMessage());
@@ -113,7 +111,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
     public function inFailNotStrict()
     {
         try {
-            A::in('boo', ['foo'], false);
+            Arrays::in('boo', ['foo'], false);
             $this->fail();
         } catch (\Exception $e) {
             $this->assertSame("Value 'boo' is not in array array (\n  0 => 'foo',\n)", $e->getMessage());
@@ -126,7 +124,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
      */
     public function inPassNotStrict()
     {
-        $this->assertSame('0', A::in('0', [0], false));
+        $this->assertSame('0', Arrays::in('0', [0], false));
     }
 
     /**
@@ -137,7 +135,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
      */
     public function inStrictNotBool()
     {
-        A::in('boo', [], 1);
+        Arrays::in('boo', [], 1);
     }
 
     /**
@@ -146,7 +144,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
      */
     public function ofScalars()
     {
-        $this->assertSame([1, 2], A::ofScalars(['1', '2'], [['uint']]));
+        $this->assertSame([1, 2], Arrays::ofScalars(['1', '2'], [['uint']]));
     }
 
     /**
@@ -155,7 +153,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
      */
     public function ofScalarsChained()
     {
-        $this->assertSame([3.3, 5.5], A::ofScalars(['a3.3', 'a5.5'], [['trim', 'a'], ['floatval']]));
+        $this->assertSame([3.3, 5.5], Arrays::ofScalars(['a3.3', 'a5.5'], [['trim', 'a'], ['floatval']]));
     }
 
     /**
@@ -164,7 +162,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
      */
     public function ofScalarsWithMeaninglessKeys()
     {
-        $this->assertSame(['key1' => 1, 'key2' => 2], A::ofScalars(['key1' => '1', 'key2' => '2'], [['uint']]));
+        $this->assertSame(['key1' => 1, 'key2' => 2], Arrays::ofScalars(['key1' => '1', 'key2' => '2'], [['uint']]));
     }
 
     /**
@@ -174,7 +172,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
     public function ofScalarsFail()
     {
         try {
-            A::ofScalars(['1', 2, 3], [['string']]);
+            Arrays::ofScalars(['1', 2, 3], [['string']]);
             $this->fail();
         } catch (\Exception $e) {
             $expected = "Field '1' with value '2' failed filtering, message 'Value '2' is not a string'\n";
@@ -190,7 +188,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
     public function ofArrays()
     {
         $expected = [['key' => 1], ['key' => 2]];
-        $this->assertSame($expected, A::ofArrays([['key' => '1'], ['key' => '2']], ['key' => [['uint']]]));
+        $this->assertSame($expected, Arrays::ofArrays([['key' => '1'], ['key' => '2']], ['key' => [['uint']]]));
     }
 
     /**
@@ -201,7 +199,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
     {
         $expected = [['key' => 3.3], ['key' => 5.5]];
         $spec = ['key' => [['trim', 'a'], ['floatval']]];
-        $this->assertSame($expected, A::ofArrays([['key' => 'a3.3'], ['key' => 'a5.5']], $spec));
+        $this->assertSame($expected, Arrays::ofArrays([['key' => 'a3.3'], ['key' => 'a5.5']], $spec));
     }
 
     /**
@@ -211,7 +209,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
     public function ofArraysRequiredAndUnknown()
     {
         try {
-            A::ofArrays([['key' => '1'], ['key2' => '2']], ['key' => ['required' => true, ['uint']]]);
+            Arrays::ofArrays([['key' => '1'], ['key2' => '2']], ['key' => ['required' => true, ['uint']]]);
             $this->fail();
         } catch (\Exception $e) {
             $expected = "Field 'key' was required and not present\nField 'key2' with value '2' is unknown";
@@ -226,7 +224,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
     public function ofArraysFail()
     {
         try {
-            A::ofArrays([['key' => '1'], ['key' => 2], ['key' => 3]], ['key' => [['string']]]);
+            Arrays::ofArrays([['key' => '1'], ['key' => 2], ['key' => 3]], ['key' => [['string']]]);
             $this->fail();
         } catch (\Exception $e) {
             $expected = "Field 'key' with value '2' failed filtering, message 'Value '2' is not a string'\n";
@@ -243,7 +241,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
     {
         $expected = ['key1' => 1, 'key2' => 2];
         $spec = ['key1' => [['uint']], 'key2' => [['uint']]];
-        $this->assertSame($expected, A::ofArray(['key1' => '1', 'key2' => '2'], $spec));
+        $this->assertSame($expected, Arrays::ofArray(['key1' => '1', 'key2' => '2'], $spec));
     }
 
     /**
@@ -254,7 +252,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
     {
         $expected = ['key' => 3.3];
         $spec = ['key' => [['trim', 'a'], ['floatval']]];
-        $this->assertSame($expected, A::ofArray(['key' => 'a3.3'], $spec));
+        $this->assertSame($expected, Arrays::ofArray(['key' => 'a3.3'], $spec));
     }
 
     /**
@@ -265,7 +263,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
     {
         $expected = ['key2' => 2];
         $spec = ['key1' => [['uint']], 'key2' => ['required' => true, ['uint']]];
-        $this->assertSame($expected, A::ofArray(['key2' => '2'], $spec));
+        $this->assertSame($expected, Arrays::ofArray(['key2' => '2'], $spec));
     }
 
     /**
@@ -275,7 +273,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
     public function ofArrayRequiredFail()
     {
         try {
-            A::ofArray(['key1' => '1'], ['key1' => [['uint']], 'key2' => ['required' => true, ['uint']]]);
+            Arrays::ofArray(['key1' => '1'], ['key1' => [['uint']], 'key2' => ['required' => true, ['uint']]]);
             $this->fail();
         } catch (\Exception $e) {
             $expected = "Field 'key2' was required and not present";
@@ -290,7 +288,7 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
     public function ofArrayUnknown()
     {
         try {
-            A::ofArray(['key' => '1'], ['key2' => [['uint']]]);
+            Arrays::ofArray(['key' => '1'], ['key2' => [['uint']]]);
             $this->fail();
         } catch (\Exception $e) {
             $expected = "Field 'key' with value '1' is unknown";
@@ -306,6 +304,6 @@ final class ArraysTest extends \PHPUnit_Framework_TestCase
      */
     public function flatten()
     {
-        $this->assertSame([1, 2, 3, 4, 5], A::flatten([[1, 2], [[3, [4, 5]]]]));
+        $this->assertSame([1, 2, 3, 4, 5], Arrays::flatten([[1, 2], [[3, [4, 5]]]]));
     }
 }

--- a/tests/Filter/BooleansTest.php
+++ b/tests/Filter/BooleansTest.php
@@ -1,8 +1,6 @@
 <?php
 namespace DominionEnterprises\Filter;
 
-use DominionEnterprises\Filter\Booleans as B;
-
 /**
  * @coversDefaultClass \DominionEnterprises\Filter\Booleans
  */
@@ -14,15 +12,15 @@ final class BooleansTest extends \PHPUnit_Framework_TestCase
      */
     public function filterBasic()
     {
-        $this->assertTrue(B::filter(true));
-        $this->assertTrue(B::filter('   true'));
-        $this->assertTrue(B::filter(' TRUE '));
-        $this->assertTrue(B::filter('True '));
+        $this->assertTrue(Booleans::filter(true));
+        $this->assertTrue(Booleans::filter('   true'));
+        $this->assertTrue(Booleans::filter(' TRUE '));
+        $this->assertTrue(Booleans::filter('True '));
 
-        $this->assertFalse(B::filter('false   '));
-        $this->assertFalse(B::filter('FALSE  '));
-        $this->assertFalse(B::filter(' False '));
-        $this->assertFalse(B::filter(false));
+        $this->assertFalse(Booleans::filter('false   '));
+        $this->assertFalse(Booleans::filter('FALSE  '));
+        $this->assertFalse(Booleans::filter(' False '));
+        $this->assertFalse(Booleans::filter(false));
     }
 
     /**
@@ -33,7 +31,7 @@ final class BooleansTest extends \PHPUnit_Framework_TestCase
      */
     public function filterAllowNullIsNotBool()
     {
-        B::filter('true', 1);
+        Booleans::filter('true', 1);
     }
 
     /**
@@ -42,7 +40,7 @@ final class BooleansTest extends \PHPUnit_Framework_TestCase
      */
     public function filterAllowNullIsTrueAndNullValue()
     {
-        $this->assertNull(B::filter(null, true));
+        $this->assertNull(Booleans::filter(null, true));
     }
 
     /**
@@ -53,7 +51,7 @@ final class BooleansTest extends \PHPUnit_Framework_TestCase
      */
     public function filterNonStringAndNonBoolValue()
     {
-        B::filter(1);
+        Booleans::filter(1);
     }
 
     /**
@@ -64,7 +62,7 @@ final class BooleansTest extends \PHPUnit_Framework_TestCase
      */
     public function filterInvalidString()
     {
-        B::filter('invalid');
+        Booleans::filter('invalid');
     }
 
     /**
@@ -73,7 +71,7 @@ final class BooleansTest extends \PHPUnit_Framework_TestCase
      */
     public function filterCustomTrueValues()
     {
-        $this->assertTrue(B::filter('Y', false, ['y']));
+        $this->assertTrue(Booleans::filter('Y', false, ['y']));
     }
 
     /**
@@ -82,7 +80,7 @@ final class BooleansTest extends \PHPUnit_Framework_TestCase
      */
     public function filterCustomFalseValues()
     {
-        $this->assertFalse(B::filter('0', false, ['true'], ['0']));
+        $this->assertFalse(Booleans::filter('0', false, ['true'], ['0']));
     }
 
     /**
@@ -93,6 +91,6 @@ final class BooleansTest extends \PHPUnit_Framework_TestCase
      */
     public function filterCustomBoolValuesInvalidString()
     {
-        $this->assertFalse(B::filter('true', false, ['y', '1'], ['n', '0']));
+        $this->assertFalse(Booleans::filter('true', false, ['y', '1'], ['n', '0']));
     }
 }

--- a/tests/Filter/DateTimeTest.php
+++ b/tests/Filter/DateTimeTest.php
@@ -1,8 +1,6 @@
 <?php
 namespace DominionEnterprises\Filter;
 
-use DominionEnterprises\Filter\DateTime as D;
-
 /**
  * Unit tests for the \DominionEnterprises\Filter\DateTime class.
  *
@@ -21,7 +19,7 @@ final class DateTimeTest extends \PHPUnit_Framework_TestCase
     public function filter()
     {
         $string = '2014-02-04T11:55:00-0500';
-        $dateTime = D::filter($string);
+        $dateTime = DateTime::filter($string);
 
         $this->assertSame(strtotime($string), $dateTime->getTimestamp());
     }
@@ -37,7 +35,7 @@ final class DateTimeTest extends \PHPUnit_Framework_TestCase
     public function filterTimestamp()
     {
         $now = time();
-        $dateTime = D::filter("@{$now}");
+        $dateTime = DateTime::filter("@{$now}");
 
         $this->assertSame($now, $dateTime->getTimestamp());
     }
@@ -56,7 +54,7 @@ final class DateTimeTest extends \PHPUnit_Framework_TestCase
      */
     public function filterEmptyValue()
     {
-        D::filter("\t \n");
+        DateTime::filter("\t \n");
     }
 
     /**
@@ -73,7 +71,7 @@ final class DateTimeTest extends \PHPUnit_Framework_TestCase
      */
     public function filterInvalidValue()
     {
-        D::filter(true);
+        DateTime::filter(true);
     }
 
     /**
@@ -86,7 +84,7 @@ final class DateTimeTest extends \PHPUnit_Framework_TestCase
      */
     public function filterAllowNullNotBoolean()
     {
-        D::filter('n/a', 5);
+        DateTime::filter('n/a', 5);
     }
 
     /**
@@ -97,7 +95,7 @@ final class DateTimeTest extends \PHPUnit_Framework_TestCase
      */
     public function filterNullAllowed()
     {
-        $this->assertNull(D::filter(null, true));
+        $this->assertNull(DateTime::filter(null, true));
     }
 
     /**
@@ -110,7 +108,7 @@ final class DateTimeTest extends \PHPUnit_Framework_TestCase
      */
     public function filterNullNotAllowed()
     {
-        D::filter(null, false);
+        DateTime::filter(null, false);
     }
 
     /**
@@ -122,7 +120,7 @@ final class DateTimeTest extends \PHPUnit_Framework_TestCase
     public function filterDateTimePass()
     {
         $dateTime = new \DateTime('now');
-        $this->assertSame($dateTime, D::filter($dateTime));
+        $this->assertSame($dateTime, DateTime::filter($dateTime));
     }
 
     /**
@@ -134,7 +132,7 @@ final class DateTimeTest extends \PHPUnit_Framework_TestCase
     public function filterWithTimeZone()
     {
         $timezone = new \DateTimeZone('Pacific/Honolulu');
-        $dateTime = D::filter('now', false, $timezone);
+        $dateTime = DateTime::filter('now', false, $timezone);
         $this->assertSame($timezone->getName(), $dateTime->getTimeZone()->getName());
         $this->assertSame(-36000, $dateTime->getOffset());
     }
@@ -148,7 +146,7 @@ final class DateTimeTest extends \PHPUnit_Framework_TestCase
     public function filterWithIntegerValue()
     {
         $now = time();
-        $dateTime = D::filter($now);
+        $dateTime = DateTime::filter($now);
         $this->assertSame($now, $dateTime->getTimestamp());
     }
 }

--- a/tests/Filter/DateTimeZoneTest.php
+++ b/tests/Filter/DateTimeZoneTest.php
@@ -1,8 +1,6 @@
 <?php
 namespace DominionEnterprises\Filter;
 
-use DominionEnterprises\Filter\DateTimeZone as TZ;
-
 /**
  * Unit tests for the \DominionEnterprises\Filter\DateTimeZone class.
  *
@@ -21,7 +19,7 @@ final class DateTimeZoneTest extends \PHPUnit_Framework_TestCase
     public function filter()
     {
         $value = 'Pacific/Honolulu';
-        $timezone = TZ::filter($value);
+        $timezone = DateTimeZone::filter($value);
         $this->assertSame($value, $timezone->getName());
         $this->assertSame(-36000, $timezone->getOffset(new \DateTime('now', $timezone)));
     }
@@ -38,7 +36,7 @@ final class DateTimeZoneTest extends \PHPUnit_Framework_TestCase
      */
     public function filterAllowNullNotBoolean()
     {
-        TZ::filter('America/New_York', 5);
+        DateTimeZone::filter('America/New_York', 5);
     }
 
     /**
@@ -51,7 +49,7 @@ final class DateTimeZoneTest extends \PHPUnit_Framework_TestCase
      */
     public function filterNullAllowed()
     {
-        $this->assertNull(TZ::filter(null, true));
+        $this->assertNull(DateTimeZone::filter(null, true));
     }
 
     /**
@@ -66,7 +64,7 @@ final class DateTimeZoneTest extends \PHPUnit_Framework_TestCase
      */
     public function filterNullNotAllowed()
     {
-        $this->assertNull(TZ::filter(null, false));
+        $this->assertNull(DateTimeZone::filter(null, false));
     }
 
     /**
@@ -80,7 +78,7 @@ final class DateTimeZoneTest extends \PHPUnit_Framework_TestCase
     public function filterTimeZonePass()
     {
         $timezone = new \DateTimeZone('America/New_York');
-        $this->assertSame($timezone, TZ::filter($timezone));
+        $this->assertSame($timezone, DateTimeZone::filter($timezone));
     }
 
     /**
@@ -93,7 +91,7 @@ final class DateTimeZoneTest extends \PHPUnit_Framework_TestCase
      */
     public function filterInvalidName()
     {
-        $timezone = TZ::filter('INVALID');
+        $timezone = DateTimeZone::filter('INVALID');
     }
 
     /**
@@ -110,7 +108,7 @@ final class DateTimeZoneTest extends \PHPUnit_Framework_TestCase
      */
     public function filterEmptyValue()
     {
-        TZ::filter("\n\t");
+        DateTimeZone::filter("\n\t");
     }
 
     /**
@@ -125,6 +123,6 @@ final class DateTimeZoneTest extends \PHPUnit_Framework_TestCase
      */
     public function filterNonStringArgument()
     {
-        $timezone = TZ::filter(42);
+        $timezone = DateTimeZone::filter(42);
     }
 }

--- a/tests/Filter/EmailTest.php
+++ b/tests/Filter/EmailTest.php
@@ -1,8 +1,6 @@
 <?php
 namespace DominionEnterprises\Filter;
 
-use DominionEnterprises\Filter\Email as E;
-
 /**
  * @coversDefaultClass \DominionEnterprises\Filter\Email
  */
@@ -15,7 +13,7 @@ final class EmailTest extends \PHPUnit_Framework_TestCase
     public function filter()
     {
         $email = 'first.last@email.com';
-        $this->assertSame($email, E::filter($email));
+        $this->assertSame($email, Email::filter($email));
     }
 
     /**
@@ -26,7 +24,7 @@ final class EmailTest extends \PHPUnit_Framework_TestCase
      */
     public function filterNonstring()
     {
-        E::filter(1);
+        Email::filter(1);
     }
 
     /**
@@ -37,6 +35,6 @@ final class EmailTest extends \PHPUnit_Framework_TestCase
      */
     public function filterNotValid()
     {
-        E::filter('@email.com');
+        Email::filter('@email.com');
     }
 }

--- a/tests/Filter/FloatsTest.php
+++ b/tests/Filter/FloatsTest.php
@@ -1,8 +1,6 @@
 <?php
 namespace DominionEnterprises\Filter;
 
-use DominionEnterprises\Filter\Floats as F;
-
 /**
  * @coversDefaultClass \DominionEnterprises\Filter\Floats
  */
@@ -16,7 +14,7 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterAllowNullIsNotBool()
     {
-        F::filter('1', 1);
+        Floats::filter('1', 1);
     }
 
     /**
@@ -27,7 +25,7 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterMinValueNotFloat()
     {
-        F::filter('1', false, 'boo');
+        Floats::filter('1', false, 'boo');
     }
 
     /**
@@ -38,7 +36,7 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterMaxValueNotFloat()
     {
-        F::filter('1', false, 1.0, 1);
+        Floats::filter('1', false, 1.0, 1);
     }
 
     /**
@@ -47,7 +45,7 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterAllowNullIsTrueAndNullValue()
     {
-        $this->assertNull(F::filter(null, true));
+        $this->assertNull(Floats::filter(null, true));
     }
 
     /**
@@ -56,7 +54,7 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterPositiveFloat()
     {
-        $this->assertSame(123.0, F::filter(123.0));
+        $this->assertSame(123.0, Floats::filter(123.0));
     }
 
     /**
@@ -65,7 +63,7 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterNegativeFloat()
     {
-        $this->assertSame(-123.0, F::filter(-123.0));
+        $this->assertSame(-123.0, Floats::filter(-123.0));
     }
 
     /**
@@ -75,8 +73,8 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
     public function filterZeroFloat()
     {
         $positiveZero = + 0.0;
-        $this->assertSame(0.0, F::filter($positiveZero));
-        $this->assertSame(-0.0, F::filter(-0.0));
+        $this->assertSame(0.0, Floats::filter($positiveZero));
+        $this->assertSame(-0.0, Floats::filter(-0.0));
     }
 
     /**
@@ -85,18 +83,18 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterPositiveString()
     {
-        $this->assertSame(123.0, F::filter('   123 '));
-        $this->assertSame(123.0, F::filter('   +123 '));
-        $this->assertSame(123.0, F::filter('   123.0 '));
-        $this->assertSame(123.0, F::filter('   123E0 '));
-        $this->assertSame(123.0, F::filter('   +123e0 '));
-        $this->assertSame(123.0, F::filter('   +1230e-1 '));
-        $this->assertSame(1230.0, F::filter('   +123e+1 '));
-        $this->assertSame(0.0, F::filter('   +0 '));
-        $this->assertSame(0.0, F::filter('   +0.0 '));
-        $this->assertSame(0.0, F::filter('   0E0 '));
-        $this->assertSame(0.0, F::filter('   00e-1 '));
-        $this->assertSame(0.0, F::filter('   00e+1 '));
+        $this->assertSame(123.0, Floats::filter('   123 '));
+        $this->assertSame(123.0, Floats::filter('   +123 '));
+        $this->assertSame(123.0, Floats::filter('   123.0 '));
+        $this->assertSame(123.0, Floats::filter('   123E0 '));
+        $this->assertSame(123.0, Floats::filter('   +123e0 '));
+        $this->assertSame(123.0, Floats::filter('   +1230e-1 '));
+        $this->assertSame(1230.0, Floats::filter('   +123e+1 '));
+        $this->assertSame(0.0, Floats::filter('   +0 '));
+        $this->assertSame(0.0, Floats::filter('   +0.0 '));
+        $this->assertSame(0.0, Floats::filter('   0E0 '));
+        $this->assertSame(0.0, Floats::filter('   00e-1 '));
+        $this->assertSame(0.0, Floats::filter('   00e+1 '));
     }
 
     /**
@@ -105,16 +103,16 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterNegativeString()
     {
-        $this->assertSame(-123.0, F::filter('   -123 '));
-        $this->assertSame(-123.0, F::filter('   -123.0 '));
-        $this->assertSame(-123.0, F::filter('   -123E0 '));
-        $this->assertSame(-123.0, F::filter('   -1230E-1 '));
-        $this->assertSame(-1230.0, F::filter('   -123e+1 '));
-        $this->assertSame(-0.0, F::filter('   -0 '));
-        $this->assertSame(-0.0, F::filter('   -0.0 '));
-        $this->assertSame(-0.0, F::filter('   -0e0 '));
-        $this->assertSame(-0.0, F::filter('   -00e-1 '));
-        $this->assertSame(-0.0, F::filter('   -0e+1 '));
+        $this->assertSame(-123.0, Floats::filter('   -123 '));
+        $this->assertSame(-123.0, Floats::filter('   -123.0 '));
+        $this->assertSame(-123.0, Floats::filter('   -123E0 '));
+        $this->assertSame(-123.0, Floats::filter('   -1230E-1 '));
+        $this->assertSame(-1230.0, Floats::filter('   -123e+1 '));
+        $this->assertSame(-0.0, Floats::filter('   -0 '));
+        $this->assertSame(-0.0, Floats::filter('   -0.0 '));
+        $this->assertSame(-0.0, Floats::filter('   -0e0 '));
+        $this->assertSame(-0.0, Floats::filter('   -00e-1 '));
+        $this->assertSame(-0.0, Floats::filter('   -0e+1 '));
     }
 
     /**
@@ -125,7 +123,7 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterNonStringOrFloat()
     {
-        F::filter(true);
+        Floats::filter(true);
     }
 
     /**
@@ -136,7 +134,7 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterEmptyString()
     {
-        F::filter('');
+        Floats::filter('');
     }
 
     /**
@@ -147,7 +145,7 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterWhitespaceString()
     {
-        F::filter('   ');
+        Floats::filter('   ');
     }
 
     /**
@@ -158,7 +156,7 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterNonDigitString()
     {
-        F::filter('123-4');
+        Floats::filter('123-4');
     }
 
     /**
@@ -168,7 +166,7 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterHexString()
     {
-        F::filter('0xFF');
+        Floats::filter('0xFF');
     }
 
     /**
@@ -179,7 +177,7 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterRogueSpaceStringAfterPeriod()
     {
-        F::filter('1. 0');
+        Floats::filter('1. 0');
     }
 
     /**
@@ -190,7 +188,7 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterRogueSpaceStringBetweenDigits()
     {
-        F::filter('1 0');
+        Floats::filter('1 0');
     }
 
     /**
@@ -201,7 +199,7 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterOverflow()
     {
-        F::filter('1e999999999999');
+        Floats::filter('1e999999999999');
     }
 
     /**
@@ -212,7 +210,7 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterUnderflow()
     {
-        F::filter('-1e999999999999');
+        Floats::filter('-1e999999999999');
     }
 
     /**
@@ -223,7 +221,7 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterLessThanMin()
     {
-        F::filter(-1.0, false, 0.0);
+        Floats::filter(-1.0, false, 0.0);
     }
 
     /**
@@ -232,7 +230,7 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterEqualToMin()
     {
-        $this->assertSame(0.0, F::filter(0.0, false, 0.0));
+        $this->assertSame(0.0, Floats::filter(0.0, false, 0.0));
     }
 
     /**
@@ -243,7 +241,7 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterGreaterThanMax()
     {
-        F::filter(1.0, false, null, 0.0);
+        Floats::filter(1.0, false, null, 0.0);
     }
 
     /**
@@ -252,7 +250,7 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterEqualToMax()
     {
-        $this->assertSame(0.0, F::filter(0.0, false, null, 0.0));
+        $this->assertSame(0.0, Floats::filter(0.0, false, null, 0.0));
     }
 
     /**
@@ -261,7 +259,7 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterCastInts()
     {
-        $this->assertSame(1.0, F::filter(1, false, null, null, true));
+        $this->assertSame(1.0, Floats::filter(1, false, null, null, true));
     }
 
     /**
@@ -272,7 +270,7 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterCastIntsIsFalse()
     {
-        F::filter(1, false, null, null, false);
+        Floats::filter(1, false, null, null, false);
     }
 
     /**
@@ -283,6 +281,6 @@ final class FloatsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterCastIntsIsNotBool()
     {
-        F::filter('1', false, null, null, 1);
+        Floats::filter('1', false, null, null, 1);
     }
 }

--- a/tests/Filter/IntsTest.php
+++ b/tests/Filter/IntsTest.php
@@ -1,8 +1,6 @@
 <?php
 namespace DominionEnterprises\Filter;
 
-use DominionEnterprises\Filter\Ints as S;
-
 /**
  * @coversDefaultClass \DominionEnterprises\Filter\Ints
  */
@@ -16,7 +14,7 @@ final class IntsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterAllowNullIsNotBool()
     {
-        S::filter('1', 1);
+        Ints::filter('1', 1);
     }
 
     /**
@@ -27,7 +25,7 @@ final class IntsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterMinValueNotInt()
     {
-        S::filter('1', false, 'boo');
+        Ints::filter('1', false, 'boo');
     }
 
     /**
@@ -38,7 +36,7 @@ final class IntsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterMaxValueNotInt()
     {
-        S::filter('1', false, 1, 1.5);
+        Ints::filter('1', false, 1, 1.5);
     }
 
     /**
@@ -47,7 +45,7 @@ final class IntsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterAllowNullIsTrueAndNullValue()
     {
-        $result = S::filter(null, true);
+        $result = Ints::filter(null, true);
         $this->assertSame(null, $result);
     }
 
@@ -57,7 +55,7 @@ final class IntsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterPositiveInt()
     {
-        $this->assertSame(123, S::filter(123));
+        $this->assertSame(123, Ints::filter(123));
     }
 
     /**
@@ -66,7 +64,7 @@ final class IntsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterNegativeInt()
     {
-        $this->assertSame(-123, S::filter(-123));
+        $this->assertSame(-123, Ints::filter(-123));
     }
 
     /**
@@ -76,8 +74,8 @@ final class IntsTest extends \PHPUnit_Framework_TestCase
     public function filterZeroInt()
     {
         $positiveZero = + 0;
-        $this->assertSame(0, S::filter($positiveZero));
-        $this->assertSame(0, S::filter(-0));
+        $this->assertSame(0, Ints::filter($positiveZero));
+        $this->assertSame(0, Ints::filter(-0));
     }
 
     /**
@@ -86,9 +84,9 @@ final class IntsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterPositiveString()
     {
-        $this->assertSame(123, S::filter('   123 '));
-        $this->assertSame(123, S::filter('   +123 '));
-        $this->assertSame(0, S::filter('   +0 '));
+        $this->assertSame(123, Ints::filter('   123 '));
+        $this->assertSame(123, Ints::filter('   +123 '));
+        $this->assertSame(0, Ints::filter('   +0 '));
     }
 
     /**
@@ -97,8 +95,8 @@ final class IntsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterNegativeString()
     {
-        $this->assertSame(-123, S::filter('   -123 '));
-        $this->assertSame(0, S::filter('   -0 '));
+        $this->assertSame(-123, Ints::filter('   -123 '));
+        $this->assertSame(0, Ints::filter('   -0 '));
     }
 
     /**
@@ -109,7 +107,7 @@ final class IntsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterNonStringOrInt()
     {
-        S::filter(true);
+        Ints::filter(true);
     }
 
     /**
@@ -120,7 +118,7 @@ final class IntsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterEmptyString()
     {
-        S::filter('');
+        Ints::filter('');
     }
 
     /**
@@ -131,7 +129,7 @@ final class IntsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterWhitespaceString()
     {
-        S::filter('   ');
+        Ints::filter('   ');
     }
 
     /**
@@ -141,7 +139,7 @@ final class IntsTest extends \PHPUnit_Framework_TestCase
     public function nonDigitString()
     {
         try {
-            S::filter('123.4');
+            Ints::filter('123.4');
             $this->fail("No exception thrown");
         } catch (\Exception $e) {
             $this->assertSame(
@@ -166,7 +164,7 @@ final class IntsTest extends \PHPUnit_Framework_TestCase
             '170141183460469231731687303715884105727' => '170141183460469231731687303715884105728',
         ];
         $oneOverMax = $maxes[(string)PHP_INT_MAX];
-        S::filter($oneOverMax);
+        Ints::filter($oneOverMax);
     }
 
     /**
@@ -183,7 +181,7 @@ final class IntsTest extends \PHPUnit_Framework_TestCase
             '-170141183460469231731687303715884105728' => '-170141183460469231731687303715884105729',
         ];
         $oneUnderMin = $mins[(string)~PHP_INT_MAX];
-        S::filter($oneUnderMin);
+        Ints::filter($oneUnderMin);
     }
 
     /**
@@ -194,7 +192,7 @@ final class IntsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterLessThanMin()
     {
-        S::filter(-1, false, 0);
+        Ints::filter(-1, false, 0);
     }
 
     /**
@@ -203,7 +201,7 @@ final class IntsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterEqualToMin()
     {
-        $this->assertSame(0, S::filter(0, false, 0));
+        $this->assertSame(0, Ints::filter(0, false, 0));
     }
 
     /**
@@ -214,7 +212,7 @@ final class IntsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterGreaterThanMax()
     {
-        S::filter(1, false, null, 0);
+        Ints::filter(1, false, null, 0);
     }
 
     /**
@@ -223,6 +221,6 @@ final class IntsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterEqualToMax()
     {
-        $this->assertSame(0, S::filter(0, false, null, 0));
+        $this->assertSame(0, Ints::filter(0, false, null, 0));
     }
 }

--- a/tests/Filter/StringsTest.php
+++ b/tests/Filter/StringsTest.php
@@ -1,8 +1,6 @@
 <?php
 namespace DominionEnterprises\Filter;
 
-use DominionEnterprises\Filter\Strings as S;
-
 /**
  * @coversDefaultClass \DominionEnterprises\Filter\Strings
  */
@@ -16,7 +14,7 @@ final class StringsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterNotString()
     {
-        S::filter(1);
+        Strings::filter(1);
     }
 
     /**
@@ -25,7 +23,7 @@ final class StringsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterNullPass()
     {
-        $this->assertSame(null, S::filter(null, true));
+        $this->assertSame(null, Strings::filter(null, true));
     }
 
     /**
@@ -36,7 +34,7 @@ final class StringsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterNullFail()
     {
-        S::filter(null);
+        Strings::filter(null);
     }
 
     /**
@@ -45,7 +43,7 @@ final class StringsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterMinLengthPass()
     {
-        $this->assertSame('a', S::filter('a'));
+        $this->assertSame('a', Strings::filter('a'));
     }
 
     /**
@@ -55,7 +53,7 @@ final class StringsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterMinLengthFail()
     {
-        S::filter('');
+        Strings::filter('');
     }
 
     /**
@@ -64,7 +62,7 @@ final class StringsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterMaxLengthPass()
     {
-        $this->assertSame('a', S::filter('a', false, 0, 1));
+        $this->assertSame('a', Strings::filter('a', false, 0, 1));
     }
 
     /**
@@ -75,7 +73,7 @@ final class StringsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterMaxLengthFail()
     {
-        S::filter('a', false, 0, 0);
+        Strings::filter('a', false, 0, 0);
     }
 
     /**
@@ -86,7 +84,7 @@ final class StringsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterAllowNullNotBoolean()
     {
-        S::filter('a', 5);
+        Strings::filter('a', 5);
     }
 
     /**
@@ -97,7 +95,7 @@ final class StringsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterMinLengthNotInteger()
     {
-        S::filter('a', false, 5.2);
+        Strings::filter('a', false, 5.2);
     }
 
     /**
@@ -108,7 +106,7 @@ final class StringsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterMaxLengthNotInteger()
     {
-        S::filter('a', false, 1, 5.2);
+        Strings::filter('a', false, 1, 5.2);
     }
 
     /**
@@ -119,7 +117,7 @@ final class StringsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterMinLengthNegative()
     {
-        S::filter('a', false, -1);
+        Strings::filter('a', false, -1);
     }
 
     /**
@@ -130,7 +128,7 @@ final class StringsTest extends \PHPUnit_Framework_TestCase
      */
     public function filterMaxLengthNegative()
     {
-        S::filter('a', false, 1, -1);
+        Strings::filter('a', false, 1, -1);
     }
 
     /**
@@ -141,7 +139,7 @@ final class StringsTest extends \PHPUnit_Framework_TestCase
      */
     public function explode()
     {
-        $this->assertSame(['a', 'bcd', 'e'], S::explode('a,bcd,e'));
+        $this->assertSame(['a', 'bcd', 'e'], Strings::explode('a,bcd,e'));
     }
 
     /**
@@ -152,7 +150,7 @@ final class StringsTest extends \PHPUnit_Framework_TestCase
      */
     public function explodeCustomDelimiter()
     {
-        $this->assertSame(['a', 'b', 'c', 'd,e'], S::explode('a b c d,e', ' '));
+        $this->assertSame(['a', 'b', 'c', 'd,e'], Strings::explode('a b c d,e', ' '));
     }
 
     /**
@@ -165,7 +163,7 @@ final class StringsTest extends \PHPUnit_Framework_TestCase
      */
     public function explodeNonStringValue()
     {
-        S::explode(true);
+        Strings::explode(true);
     }
 
     /**
@@ -178,7 +176,7 @@ final class StringsTest extends \PHPUnit_Framework_TestCase
      */
     public function explodeNonStringDelimiter()
     {
-        S::explode('test', 4);
+        Strings::explode('test', 4);
     }
 
     /**
@@ -191,6 +189,6 @@ final class StringsTest extends \PHPUnit_Framework_TestCase
      */
     public function explodeEmptyDelimiter()
     {
-        S::explode('test', '');
+        Strings::explode('test', '');
     }
 }

--- a/tests/Filter/UnsignedIntTest.php
+++ b/tests/Filter/UnsignedIntTest.php
@@ -1,8 +1,6 @@
 <?php
 namespace DominionEnterprises\Filter;
 
-use DominionEnterprises\Filter\UnsignedInt as I;
-
 /**
  * @coversDefaultClass \DominionEnterprises\Filter\UnsignedInt
  */
@@ -16,7 +14,7 @@ final class UnsignedIntTest extends \PHPUnit_Framework_TestCase
      */
     public function filterMinValueNegative()
     {
-        I::filter('1', false, -1);
+        UnsignedInt::filter('1', false, -1);
     }
 
     /**
@@ -25,7 +23,7 @@ final class UnsignedIntTest extends \PHPUnit_Framework_TestCase
      */
     public function filterMinValueNullSuccess()
     {
-        $this->assertSame(1, I::filter('1', false, null));
+        $this->assertSame(1, UnsignedInt::filter('1', false, null));
     }
 
     /**
@@ -36,7 +34,7 @@ final class UnsignedIntTest extends \PHPUnit_Framework_TestCase
      */
     public function filterMinValueNullFail()
     {
-        I::filter('-1', false, null);
+        UnsignedInt::filter('-1', false, null);
     }
 
     /**
@@ -45,7 +43,7 @@ final class UnsignedIntTest extends \PHPUnit_Framework_TestCase
      */
     public function filterBasicUse()
     {
-        $this->assertSame(123, I::filter('123'));
+        $this->assertSame(123, UnsignedInt::filter('123'));
     }
 
     /**
@@ -54,7 +52,7 @@ final class UnsignedIntTest extends \PHPUnit_Framework_TestCase
      */
     public function filterAllowNullSuccess()
     {
-        $this->assertSame(null, I::filter(null, true));
+        $this->assertSame(null, UnsignedInt::filter(null, true));
     }
 
     /**
@@ -65,7 +63,7 @@ final class UnsignedIntTest extends \PHPUnit_Framework_TestCase
      */
     public function filterAllowNullFail()
     {
-        I::filter(null, false);
+        UnsignedInt::filter(null, false);
     }
 
     /**
@@ -76,7 +74,7 @@ final class UnsignedIntTest extends \PHPUnit_Framework_TestCase
      */
     public function filterMinValueFail()
     {
-        $this->assertSame(1, I::filter('0', false, 1));
+        $this->assertSame(1, UnsignedInt::filter('0', false, 1));
     }
 
     /**
@@ -87,6 +85,6 @@ final class UnsignedIntTest extends \PHPUnit_Framework_TestCase
      */
     public function filterMaxValueFail()
     {
-        I::filter('2', false, 0, 1);
+        UnsignedInt::filter('2', false, 0, 1);
     }
 }

--- a/tests/Filter/UrlTest.php
+++ b/tests/Filter/UrlTest.php
@@ -1,8 +1,6 @@
 <?php
 namespace DominionEnterprises\Filter;
 
-use DominionEnterprises\Filter\Url as U;
-
 /**
  * @coversDefaultClass \DominionEnterprises\Filter\Url
  */
@@ -15,7 +13,7 @@ final class UrlTest extends \PHPUnit_Framework_TestCase
     public function filter()
     {
         $url = 'http://www.example.com';
-        $this->assertSame($url, U::filter($url));
+        $this->assertSame($url, Url::filter($url));
     }
 
     /**
@@ -26,7 +24,7 @@ final class UrlTest extends \PHPUnit_Framework_TestCase
      */
     public function filterNonstring()
     {
-        U::filter(1);
+        Url::filter(1);
     }
 
     /**
@@ -37,6 +35,6 @@ final class UrlTest extends \PHPUnit_Framework_TestCase
      */
     public function filterNotValid()
     {
-        U::filter('www.example.com');
+        Url::filter('www.example.com');
     }
 }

--- a/tests/FiltererTest.php
+++ b/tests/FiltererTest.php
@@ -2,8 +2,6 @@
 
 namespace DominionEnterprises;
 
-use DominionEnterprises\Filterer as F;
-
 /**
  * @coversDefaultClass \DominionEnterprises\Filterer
  */
@@ -15,7 +13,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function requiredPass()
     {
-        $result = F::filter(['fieldOne' => ['required' => false]], []);
+        $result = Filterer::filter(['fieldOne' => ['required' => false]], []);
         $this->assertSame([true, [], null, []], $result);
     }
 
@@ -25,7 +23,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function requiredFail()
     {
-        $result = F::filter(['fieldOne' => ['required' => true]], []);
+        $result = Filterer::filter(['fieldOne' => ['required' => true]], []);
         $this->assertSame([false, null, "Field 'fieldOne' was required and not present", []], $result);
     }
 
@@ -35,7 +33,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function requiredWithADefaultWithoutInput()
     {
-        $result = F::filter(['fieldOne' => ['required' => true, 'default' => 'theDefault']], []);
+        $result = Filterer::filter(['fieldOne' => ['required' => true, 'default' => 'theDefault']], []);
         $this->assertSame([true, ['fieldOne' => 'theDefault'], null, []], $result);
     }
 
@@ -45,7 +43,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function requiredWithANullDefaultWithoutInput()
     {
-        $result = F::filter(['fieldOne' => ['required' => true, 'default' => null]], []);
+        $result = Filterer::filter(['fieldOne' => ['required' => true, 'default' => null]], []);
         $this->assertSame([true, ['fieldOne' => null], null, []], $result);
     }
 
@@ -55,7 +53,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function requiredWithADefaultWithInput()
     {
-        $result = F::filter(
+        $result = Filterer::filter(
             ['fieldOne' => ['required' => true, 'default' => 'theDefault']],
             ['fieldOne' => 'notTheDefault']
         );
@@ -68,7 +66,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function notRequiredWithADefaultWithoutInput()
     {
-        $result = F::filter(['fieldOne' => ['default' => 'theDefault']], []);
+        $result = Filterer::filter(['fieldOne' => ['default' => 'theDefault']], []);
         $this->assertSame([true, ['fieldOne' => 'theDefault'], null, []], $result);
     }
 
@@ -78,7 +76,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function notRequiredWithADefaultWithInput()
     {
-        $result = F::filter(['fieldOne' => ['default' => 'theDefault']], ['fieldOne' => 'notTheDefault']);
+        $result = Filterer::filter(['fieldOne' => ['default' => 'theDefault']], ['fieldOne' => 'notTheDefault']);
         $this->assertSame([true, ['fieldOne' => 'notTheDefault'], null, []], $result);
     }
 
@@ -88,7 +86,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function requiredDefaultPass()
     {
-        $result = F::filter(['fieldOne' => []], []);
+        $result = Filterer::filter(['fieldOne' => []], []);
         $this->assertSame([true, [], null, []], $result);
     }
 
@@ -98,7 +96,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function requiredDefaultFail()
     {
-        $result = F::filter(['fieldOne' => []], [], ['defaultRequired' => true]);
+        $result = Filterer::filter(['fieldOne' => []], [], ['defaultRequired' => true]);
         $this->assertSame([false, null, "Field 'fieldOne' was required and not present", []], $result);
     }
 
@@ -108,7 +106,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function filterPass()
     {
-        $result = F::filter(['fieldOne' => [['floatval']]], ['fieldOne' => '3.14']);
+        $result = Filterer::filter(['fieldOne' => [['floatval']]], ['fieldOne' => '3.14']);
         $this->assertSame([true, ['fieldOne' => 3.14], null, []], $result);
     }
 
@@ -118,7 +116,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function filterDefaultShortNamePass()
     {
-        $result = F::filter(['fieldOne' => [['float']]], ['fieldOne' => '3.14']);
+        $result = Filterer::filter(['fieldOne' => [['float']]], ['fieldOne' => '3.14']);
         $this->assertSame([true, ['fieldOne' => 3.14], null, []], $result);
     }
 
@@ -129,8 +127,8 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function filterCustomShortNamePass()
     {
-        F::setFilterAliases(['fval' => 'floatval']);
-        $result = F::filter(['fieldOne' => [['fval']]], ['fieldOne' => '3.14']);
+        Filterer::setFilterAliases(['fval' => 'floatval']);
+        $result = Filterer::filter(['fieldOne' => [['fval']]], ['fieldOne' => '3.14']);
         $this->assertSame([true, ['fieldOne' => 3.14], null, []], $result);
     }
 
@@ -143,8 +141,8 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
     public function filterGetSetKnownFilters()
     {
         $knownFilters = ['lower' => 'strtolower', 'upper' => 'strtoupper'];
-        F::setFilterAliases($knownFilters);
-        $this->assertSame($knownFilters, F::getFilterAliases());
+        Filterer::setFilterAliases($knownFilters);
+        $this->assertSame($knownFilters, Filterer::getFilterAliases());
     }
 
     /**
@@ -153,7 +151,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function filterFail()
     {
-        $result = F::filter(
+        $result = Filterer::filter(
             ['fieldOne' => [['\DominionEnterprises\FiltererTest::failingFilter']]],
             ['fieldOne' => 'valueOne']
         );
@@ -169,7 +167,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function chainPass()
     {
-        $result = F::filter(['fieldOne' => [['trim', 'a'], ['floatval']]], ['fieldOne' => 'a3.14']);
+        $result = Filterer::filter(['fieldOne' => [['trim', 'a'], ['floatval']]], ['fieldOne' => 'a3.14']);
         $this->assertSame([true, ['fieldOne' => 3.14], null, []], $result);
     }
 
@@ -179,7 +177,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function chainFail()
     {
-        $result = F::filter(
+        $result = Filterer::filter(
             ['fieldOne' => [['trim'], ['\DominionEnterprises\FiltererTest::failingFilter']]],
             ['fieldOne' => 'the value']
         );
@@ -195,7 +193,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function multiInputPass()
     {
-        $result = F::filter(
+        $result = Filterer::filter(
             ['fieldOne' => [['trim']], 'fieldTwo' => [['strtoupper']]],
             ['fieldOne' => ' value', 'fieldTwo' => 'bob']
         );
@@ -208,7 +206,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function multiInputFail()
     {
-        $result = F::filter(
+        $result = Filterer::filter(
             [
                 'fieldOne' => [['\DominionEnterprises\FiltererTest::failingFilter']],
                 'fieldTwo' => [['\DominionEnterprises\FiltererTest::failingFilter']],
@@ -226,7 +224,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function emptyFilter()
     {
-        $result = F::filter(['fieldOne' => [[]]], ['fieldOne' => 0]);
+        $result = Filterer::filter(['fieldOne' => [[]]], ['fieldOne' => 0]);
         $this->assertSame([true, ['fieldOne' => 0], null, []], $result);
     }
 
@@ -236,7 +234,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function unknownsAllowed()
     {
-        $result = F::filter([], ['fieldTwo' => 0], ['allowUnknowns' => true]);
+        $result = Filterer::filter([], ['fieldTwo' => 0], ['allowUnknowns' => true]);
         $this->assertSame([true, [], null, ['fieldTwo' => 0]], $result);
     }
 
@@ -246,7 +244,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function unknownsNotAllowed()
     {
-        $result = F::filter([], ['fieldTwo' => 0]);
+        $result = Filterer::filter([], ['fieldTwo' => 0]);
         $this->assertSame([false, null, "Field 'fieldTwo' with value '0' is unknown", ['fieldTwo' => 0]], $result);
     }
 
@@ -256,7 +254,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function objectFilter()
     {
-        $result = F::filter(['fieldOne' => [[[$this, 'passingFilter']]]], ['fieldOne' => 'foo']);
+        $result = Filterer::filter(['fieldOne' => [[[$this, 'passingFilter']]]], ['fieldOne' => 'foo']);
         $this->assertSame([true, ['fieldOne' => 'fooboo'], null, []], $result);
     }
 
@@ -268,7 +266,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function notCallable()
     {
-        F::filter(['foo' => [['boo']]], ['foo' => 0]);
+        Filterer::filter(['foo' => [['boo']]], ['foo' => 0]);
     }
 
     /**
@@ -279,7 +277,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function allowUnknownsNotBool()
     {
-        F::filter([], [], ['allowUnknowns' => 1]);
+        Filterer::filter([], [], ['allowUnknowns' => 1]);
     }
 
     /**
@@ -290,7 +288,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function defaultRequiredNotBool()
     {
-        F::filter([], [], ['defaultRequired' => 1]);
+        Filterer::filter([], [], ['defaultRequired' => 1]);
     }
 
     /**
@@ -301,7 +299,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function filtersNotArrayInLeftOverSpec()
     {
-        F::filter(['boo' => 1], []);
+        Filterer::filter(['boo' => 1], []);
     }
 
     /**
@@ -312,7 +310,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function filtersNotArrayWithInput()
     {
-        F::filter(['boo' => 1], ['boo' => 'notUnderTest']);
+        Filterer::filter(['boo' => 1], ['boo' => 'notUnderTest']);
     }
 
     /**
@@ -323,7 +321,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function filterNotArray()
     {
-        F::filter(['boo' => [1]], ['boo' => 'notUnderTest']);
+        Filterer::filter(['boo' => [1]], ['boo' => 'notUnderTest']);
     }
 
     /**
@@ -334,7 +332,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function requiredNotBool()
     {
-        F::filter(['boo' => ['required' => 1]], []);
+        Filterer::filter(['boo' => ['required' => 1]], []);
     }
 
     /**
@@ -345,7 +343,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function registerAliasAliasNotString()
     {
-        F::registerAlias(true, 'strtolower');
+        Filterer::registerAlias(true, 'strtolower');
     }
 
     /**
@@ -356,7 +354,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function registerAliasOverwriteNotBool()
     {
-        F::registerAlias('lower', 'strtolower', 'foo');
+        Filterer::registerAlias('lower', 'strtolower', 'foo');
     }
 
     /**
@@ -367,9 +365,9 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function registerExistingAliasOverwriteFalse()
     {
-        F::setFilterAliases([]);
-        F::registerAlias('upper', 'strtoupper');
-        F::registerAlias('upper', 'strtoupper', false);
+        Filterer::setFilterAliases([]);
+        Filterer::registerAlias('upper', 'strtoupper');
+        Filterer::registerAlias('upper', 'strtoupper', false);
     }
 
     /**
@@ -378,9 +376,9 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function registerExistingAliasOverwriteTrue()
     {
-        F::setFilterAliases(['upper' => 'strtoupper', 'lower' => 'strtolower']);
-        F::registerAlias('upper', 'ucfirst', true);
-        $this->assertSame(['upper' => 'ucfirst', 'lower' => 'strtolower'], F::getFilterAliases());
+        Filterer::setFilterAliases(['upper' => 'strtoupper', 'lower' => 'strtolower']);
+        Filterer::registerAlias('upper', 'ucfirst', true);
+        $this->assertSame(['upper' => 'ucfirst', 'lower' => 'strtolower'], Filterer::getFilterAliases());
     }
 
     public static function failingFilter($val)
@@ -403,7 +401,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function filterWithCustomError()
     {
-        $result = F::filter(
+        $result = Filterer::filter(
             [
                 'fieldOne' => [
                     ['\DominionEnterprises\FiltererTest::failingFilter'],
@@ -430,7 +428,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function filterWithNonStringError()
     {
-        F::filter(
+        Filterer::filter(
             ['fieldOne' => [['strtoupper'], 'error' => new \StdClass()]],
             ['fieldOne' => 'valueOne']
         );
@@ -448,7 +446,7 @@ final class FiltererTest extends \PHPUnit_Framework_TestCase
      */
     public function filterWithEmptyStringError()
     {
-        F::filter(
+        Filterer::filter(
             ['fieldOne' => [['strtoupper'], 'error' => "\n   \t"]],
             ['fieldOne' => 'valueOne']
         );


### PR DESCRIPTION
@chadicus @tmli3b3rm4n this gets rid of all the aliasing in the tests.