### PR TITLE
Allow Null for URL Filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,8 @@ assert($value === ['abc', 'def', 'ghi']);
 
 #### Url::filter
 Aliased in the filterer as `url`, this filter verifies that the argument is a URL string according to
-[RFC2396](http://www.faqs.org/rfcs/rfc2396).
+[RFC2396](http://www.faqs.org/rfcs/rfc2396). The second parameter can be set to `true` to allow
+null values through without an error (they will stay null and not get converted to false).
 
 The following checks that `$value` is a URL.
 ```php

--- a/src/Filter/Url.php
+++ b/src/Filter/Url.php
@@ -16,15 +16,26 @@ final class Url
      * Filters value as URL (according to » http://www.faqs.org/rfcs/rfc2396)
      *
      * The return value is the url, as expected by the \DominionEnterprises\Filterer class.
+     * By default, nulls are not allowed.
      *
      * @param mixed $value The value to filter.
+     * @param bool $allowNull True to allow nulls through, and false (default) if nulls should not be allowed.
      *
      * @return string The passed in $value.
      *
      * @throws \Exception if the value did not pass validation.
+     * @throws \InvalidArgumentException if one of the parameters was not correctly typed.
      */
-    public static function filter($value)
+    public static function filter($value, $allowNull = false)
     {
+        if ($allowNull !== false && $allowNull !== true) {
+            throw new \InvalidArgumentException('$allowNull was not a boolean value');
+        }
+
+        if ($allowNull === true && $value === null) {
+            return null;
+        }
+
         if (!is_string($value)) {
             throw new \Exception("Value '" . var_export($value, true) . "' is not a string");
         }

--- a/tests/Filter/UrlTest.php
+++ b/tests/Filter/UrlTest.php
@@ -37,4 +37,35 @@ final class UrlTest extends \PHPUnit_Framework_TestCase
     {
         Url::filter('www.example.com');
     }
+
+    /**
+     * @test
+     * @covers ::filter
+     */
+    public function filterNullPass()
+    {
+        $this->assertSame(null, Url::filter(null, true));
+    }
+
+    /**
+     * @test
+     * @expectedException Exception
+     * @expectedExceptionMessage Value 'NULL' is not a string
+     * @covers ::filter
+     */
+    public function filterNullFail()
+    {
+        Url::filter(null);
+    }
+
+    /**
+     * @test
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage $allowNull was not a boolean value
+     * @covers ::filter
+     */
+    public function filterAllowNullNotBoolean()
+    {
+        Url::filter('a', 5);
+    }
 }


### PR DESCRIPTION
Allowing Null to be passed for cases where we want to blank out the field